### PR TITLE
Setup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,14 @@ A python API for implementing aXe-style calibration and common grism functions.
 
 ## Installation
 
-1. h5axeconfig has three key dependencies that must be resolved first: [h5py](https://pypi.org/project/h5py/), [ruamel](https://pypi.org/project/ruamel.yaml/), and [wget](https://pypi.org/project/wget/).
+1. Now you can install h5axeconfig using the standard:
+```
+pip install .
+```
+## Development
 
 ```
-pip install h5py
-pip install wget
-pip install ruamel.yaml
-```
-2. Now you can install h5axeconfig using the standard:
-```
-python setup.py install
+pip install -e .
 ```
 
 ## Calibration Files

--- a/h5axeconfig/__init__.py
+++ b/h5axeconfig/__init__.py
@@ -1,13 +1,5 @@
 
-__author__='Russell Ryan'
-__version__='0.9'
-__maintainer__='Russell Ryan'
-__email__='rryan@stsci.edu'
-__status__='Production'
-__credits__='Russell Ryan'
-
-
-
+from . import info
 from .grism import Camera
 from .grism import FlatField
 from .siaf import SIAF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=38.2.5",
+    "wheel",
+    "wget"
+]

--- a/setup.py
+++ b/setup.py
@@ -2,51 +2,53 @@ from setuptools import setup,find_packages
 import os
 import shutil
 import urllib.request
-import h5axeconfig.__init__ as info
-
-try:
-    import wget
-except:
-    print('Must install wget:\npip install wget')
-    exit()
+import wget
 
 
-# the data dir 
+# the data dir
 datadir='h5axeconfig/data'
 if not os.path.isdir(datadir):
-  os.mkdir(datadir)
+    os.mkdir(datadir)
 
-print("You will need to download the HDF5 files made by Russell Ryan")
-print("Do you want the setup.py to download these files? [y]/n")
-q=input()
-if (q=='y') | (q=='Y') | (q=='') :
-    rooturl='http://www.stsci.edu/~rryan/pyLINEAR/calibrations/'
-    with urllib.request.urlopen(rooturl+'all.txt') as www:
-        for line in www:
-            name=line.strip().decode('utf-8')
-            base=os.path.basename(name)
-            if not os.path.isfile(os.path.join(datadir,base)):
-                print("Downloading: {}\n".format(base))
-                thisFile=wget.download(rooturl+name)
-                #os.rename(thisFile,datadir)
-                shutil.move(thisFile,os.path.join(datadir,thisFile))
+rooturl='http://www.stsci.edu/~rryan/pyLINEAR/calibrations/'
+with urllib.request.urlopen(rooturl+'all.txt') as www:
+    for line in www:
+        name=line.strip().decode('utf-8')
+        base=os.path.basename(name)
+        if not os.path.isfile(os.path.join(datadir,base)):
+            print("Downloading: {}\n".format(base))
+            thisFile=wget.download(rooturl+name)
+            #os.rename(thisFile,datadir)
+            shutil.move(thisFile,os.path.join(datadir,thisFile))
+
+PKG = 'h5axeconfig'
+AUTHOR = 'Russell Ryan'
+info = {
+    '__author__': AUTHOR,
+    '__version__': '1.0',
+    '__maintainer__': AUTHOR,
+    '__email__': 'rryan@stsci.edu',
+    '__credits__': AUTHOR,
+}
+
+# Generate package metadata
+with open(os.path.join(PKG, 'info.py'), 'w+') as fp:
+    for k, v in info.items():
+        fp.write('{} = "{}"{}'.format(k, v, os.linesep))
 
 # call setup
-setup(name='h5axeconfig',\
-      version=info.__version__,\
-      author=info.__author__,\
-      author_email=info.__email__,\
-      keywords='grism aXe python hdf5',\
-      description='Python API for working with grism configuration in aXe format written as HDF5',\
+setup(name=PKG,
+      version=info['__version__'],
+      author=info['__author__'],
+      author_email=info['__email__'],
+      keywords='grism aXe python hdf5',
+      description='Python API for working with grism configuration in aXe format written as HDF5',
       license='MIT',
-      install_requires=['h5py','wget','astropy','numpy','polyclip'],
-      classifiers=['Development Status :: 5 Production/Stable',\
+      setup_requires=['wget'],
+      install_requires=['h5py','astropy','numpy', 'polyclip @ git+https://github.com/russell-ryan/polyclip#egg=polyclip'],
+      classifiers=['Development Status :: 5 Production/Stable',
                    'Intended Audience :: Science/Research',
-                   'Topic :: Scientific/Engineering :: Astronomy',],\
-      packages=find_packages(),\
-      package_dir={'h5axeconfig': 'h5axeconfig'},\
+                   'Topic :: Scientific/Engineering :: Astronomy',],
+      packages=find_packages(),
+      package_dir={'h5axeconfig': 'h5axeconfig'},
       package_data={'h5axeconfig':['data/*.h5']})
-
-      
-
-      


### PR DESCRIPTION
Try to improve quality of life for the end-user.

Due to the way we're pulling from `polyclip`'s repo, you must install this package using `pip install .` or `pip install -e .` for development mode.